### PR TITLE
Set CONFIG_NFCT_PINS_AS_GPIOS in mbed_app.json

### DIFF
--- a/custom_targets.json
+++ b/custom_targets.json
@@ -18,7 +18,8 @@
             "NRF52_PAN_58",
             "NRF52_PAN_62",
             "NRF52_PAN_63",
-            "NRF52_PAN_64"
+            "NRF52_PAN_64",
+            "CONFIG_NFCT_PINS_AS_GPIOS"
         ],
         "device_has_remove": ["ITM"],
         "overrides": {

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -1,6 +1,5 @@
 {
     "artifact_name": "mbedos-nrf52-starter",
-    "macros": ["CONFIG_NFCT_PINS_AS_GPIOS"],
     "target_overrides": {
         "*": {
             "platform.stack-stats-enabled": true,


### PR DESCRIPTION
Allows P0_9 and P0_10 (GPIO2/4) to be used as GPIO

Closes https://github.com/microbit-foundation/microbit-design/issues/126